### PR TITLE
Initialize the list of Facebook valid IPs lazily [closes #7]

### DIFF
--- a/legitbot.gemspec
+++ b/legitbot.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
     "made by a real search engine, not a fake"
 
   spec.required_ruby_version = '>= 2.0.0'
-  spec.add_dependency "irrc"
+  spec.add_dependency "irrc", ">= 0.2.1"
   spec.add_dependency "segment_tree"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"

--- a/lib/legitbot/facebook.rb
+++ b/lib/legitbot/facebook.rb
@@ -1,18 +1,31 @@
-require 'segment_tree'
-require 'irrc'
-require 'monitor'
 require 'ipaddr'
+require 'irrc'
+require 'segment_tree'
 
 module Legitbot
   # https://developers.facebook.com/docs/sharing/webmasters/crawler
 
   class Facebook < BotMatch
-    lock = Monitor.new
-
     AS = 'AS32934'
-    ValidIPs = lock.synchronize do
+
+    def valid?
+      ip = IPAddr.new(@ip)
+      Facebook.valid_ips[ip.ipv4? ? :ipv4 : :ipv6].find(ip)
+    end
+
+    @mutex = Mutex.new
+
+    def self.valid_ips
+      @mutex.synchronize { @ips ||= load_ips }
+    end
+
+    def self.reload!
+      @mutex.synchronize { @ips = load_ips }
+    end
+
+    def self.load_ips
       client = Irrc::Client.new
-      client.query :radb, 'AS32934'
+      client.query :radb, AS
       results = client.perform
 
       Hash[%i(ipv4 ipv6).map { |k|
@@ -20,11 +33,6 @@ module Legitbot
             [IPAddr.new(cidr).to_range, true]
           })]
       }]
-    end
-
-    def valid?
-      ip = IPAddr.new(@ip)
-      ValidIPs[ip.ipv4? ? :ipv4 : :ipv6].find(ip)
     end
   end
 

--- a/lib/legitbot/version.rb
+++ b/lib/legitbot/version.rb
@@ -1,3 +1,3 @@
 module Legitbot
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end


### PR DESCRIPTION
@yjukaku, I need your help. I am not an expert in Ruby concurrency, so I hope you are. I shall appreciate if you'd review this PR. My goal here is to make `Legitbot::Facebook.valid_ips` thread safe.

I've seen your bug report https://github.com/codeout/irrc/issues/3 , that's why `Gemfile` includes "irrc" from Github. What's weird here is that tests fail locally on my machine, but they passed on TravisCI.