### PR TITLE
Updates DuckDuckBot IP addresses

### DIFF
--- a/lib/legitbot/duckduckgo.rb
+++ b/lib/legitbot/duckduckgo.rb
@@ -1,7 +1,7 @@
 module Legitbot
   # https://duckduckgo.com/duckduckbot
   class DuckDuckGo < BotMatch
-    ValidIPs = %w(72.94.249.34 72.94.249.35 72.94.249.36 72.94.249.37 72.94.249.38)
+    ValidIPs = %w(107.20.237.51 23.21.226.191 107.21.1.8 54.208.102.37)
 
     def valid?
       DuckDuckGo::ValidIPs.include? @ip


### PR DESCRIPTION
The current list of IP addresses has changed: https://duckduckgo.com/duckduckbot