### PR TITLE
Updates the UA string for DuckDuckGo bot

### DIFF
--- a/lib/legitbot/duckduckgo.rb
+++ b/lib/legitbot/duckduckgo.rb
@@ -8,5 +8,5 @@ module Legitbot
     end
   end
 
-  rule Legitbot::DuckDuckGo, %w(DuckDuckGo)
+  rule Legitbot::DuckDuckGo, %w(DuckDuckBot)
 end


### PR DESCRIPTION
This should resolve #15 

Relevant documentation: https://help.duckduckgo.com/duckduckgo-help-pages/results/duckduckbot/

I'm not sure how reliable this information is but I'm linking it anyways: https://user-agents.net/string/duckduckbot-1-0-http-duckduckgo-com-duckduckbot-html

I personally tested and indeed the latest DDG iOS app has the following UserAgent string: `User-Agent: Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 DuckDuckGo/7`