### PR TITLE
Fix up IPv6 nil exception

### DIFF
--- a/lib/legitbot/validators/ip_ranges.rb
+++ b/lib/legitbot/validators/ip_ranges.rb
@@ -40,7 +40,7 @@ module Legitbot
 
           obj = IPAddr.new(ip)
           ranges = valid_ips[obj.ipv4? ? :ipv4 : :ipv6].search(obj.to_i)
-          !ranges.empty?
+          !ranges.nil? && !ranges.empty?
         end
 
         def valid_ips

--- a/test/legitbot/validators/ip_ranges_test.rb
+++ b/test/legitbot/validators/ip_ranges_test.rb
@@ -51,6 +51,11 @@ module Legitbot
       ip_ranges { nil }
     end
 
+    class Ipv4Ranges
+      include IpRanges
+      ip_ranges { ['66.220.144.0/21'] }
+    end
+
     class IpRangesTest < Minitest::Test
       def test_partition_method
         empty = NoRanges.partition_ips([])
@@ -116,6 +121,10 @@ module Legitbot
 
       def test_nil_ranges
         assert NilRanges.valid_ip?('127.0.0.1')
+      end
+
+      def test_ipv4_only_ranges
+        refute Ipv4Ranges.valid_ip?('2a03:2880:f234:0:0:0:0:1')
       end
     end
   end


### PR DESCRIPTION
As titled, we recently found an exception from legitbot internal, which was caused by an IPv6 IP being checked againt IP ranges including only IPv4 addresses.