### PR TITLE
Switch to `fast_interval_tree`

### DIFF
--- a/legitbot.gemspec
+++ b/legitbot.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   }
 
   spec.required_ruby_version = '>= 2.5.0'
-  spec.add_dependency 'augmented_interval_tree', '~> 0.1', '>= 0.1.1'
+  spec.add_dependency 'fast_interval_tree', '~> 0.2', '>= 0.2.2'
   spec.add_dependency 'irrc', '~> 0.2', '>= 0.2.1'
   spec.add_development_dependency 'bump', '~> 0.8', '>= 0.8.0'
   spec.add_development_dependency 'minitest', '~> 5.1', '>= 5.1.0'


### PR DESCRIPTION
`augmented_interval_tree` was transferred to `greensync/interval-tree` and has been distributed as `fast_interval_tree`:
https://github.com/greensync/interval-tree/pull/8#issuecomment-725848565