### PR TITLE
Mock DNS in tests

### DIFF
--- a/legitbot.gemspec
+++ b/legitbot.gemspec
@@ -23,12 +23,14 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'fast_interval_tree', '~> 0.2', '>= 0.2.2'
   spec.add_dependency 'irrc', '~> 0.2', '>= 0.2.1'
   spec.add_development_dependency 'bump', '~> 0.8', '>= 0.8.0'
+  spec.add_development_dependency 'dns_mock', '~> 1.5.0', '>= 1.5.0'
   spec.add_development_dependency 'minitest', '~> 5.1', '>= 5.1.0'
+  spec.add_development_dependency 'minitest-hooks', '~> 1.5', '>= 1.5.0'
   spec.add_development_dependency 'rake', '~> 13.0', '>= 13.0.0'
   spec.add_development_dependency 'rubocop', '~> 1.24.0', '>= 1.24.0'
   spec.add_development_dependency 'rubocop-minitest', '~> 0.17.0', '>= 0.17.0'
 
   spec.files = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.rdoc_options = ['--charset=UTF-8']
-  spec.test_files = Dir.glob('test/**/*')
+  spec.test_files = Dir.glob('test/**/*').reject { |f| f.start_with? 'test/lib' }
 end

--- a/test/ahrefs_test.rb
+++ b/test/ahrefs_test.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
 require 'minitest/autorun'
+require 'minitest/hooks/test'
+require 'lib/dns_server_mock'
 require 'legitbot'
 
 class AhrefsTest < Minitest::Test
+  include Minitest::Hooks
+  include DnsServerMock
+
   def test_malicious_ip
     ip = '149.210.164.47'
     match = Legitbot::Ahrefs.new ip

--- a/test/alexa_test.rb
+++ b/test/alexa_test.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
 require 'minitest/autorun'
+require 'minitest/hooks/test'
+require 'lib/dns_server_mock'
 require 'legitbot'
 
 class AlexaTest < Minitest::Test
+  include Minitest::Hooks
+  include DnsServerMock
+
   def test_malicious_ip
     ip = '149.210.164.47'
     match = Legitbot::Alexa.new ip

--- a/test/amazon_test.rb
+++ b/test/amazon_test.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
 require 'minitest/autorun'
+require 'minitest/hooks/test'
+require 'lib/dns_server_mock'
 require 'legitbot'
 
 class AmazonTest < Minitest::Test
+  include Minitest::Hooks
+  include DnsServerMock
+
   def test_malicious_ip
     ip = '149.210.164.47'
     match = Legitbot::Amazon.new ip

--- a/test/apple_test.rb
+++ b/test/apple_test.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
 require 'minitest/autorun'
+require 'minitest/hooks/test'
+require 'lib/dns_server_mock'
 require 'legitbot'
 
 class AppleTest < Minitest::Test
+  include Minitest::Hooks
+  include DnsServerMock
+
   def test_valid_ip
     ip = '17.58.98.60'
     match = Legitbot::Apple.new(ip)

--- a/test/botmatch_test.rb
+++ b/test/botmatch_test.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
 require 'minitest/autorun'
+require 'minitest/hooks/test'
+require 'lib/dns_server_mock'
 require 'legitbot'
 
 class BotMatchTest < Minitest::Test
+  include Minitest::Hooks
+  include DnsServerMock
+
   def test_valid_class_syntax
     assert Legitbot::Google.valid?('66.249.64.141')
     assert Legitbot::Google.fake?('149.210.164.47')

--- a/test/google_test.rb
+++ b/test/google_test.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
 require 'minitest/autorun'
+require 'minitest/hooks/test'
+require 'lib/dns_server_mock'
 require 'legitbot'
 
 class GoogleTest < Minitest::Test
+  include Minitest::Hooks
+  include DnsServerMock
+
   def test_malicious_ip
     ip = '149.210.164.47'
     match = Legitbot::Google.new ip

--- a/test/lib/dns_server_mock.rb
+++ b/test/lib/dns_server_mock.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'dns_mock'
+require 'json'
+
+TEST_DNS_RECORDS = {
+  # Malicious
+  '149.210.164.47' => {
+    ptr: %w[malicious.spam.co]
+  },
+
+  # Ahrefs
+  'ip-54-36-148-0.a.ahrefs.com' => {
+    a: %w[54.36.148.0]
+  },
+  '54.36.148.0' => {
+    ptr: %w[ip-54-36-148-0.a.ahrefs.com]
+  },
+
+  # Alexa
+  '52.86.176.3' => {
+    ptr: %w[crawl-52-86-176-3.alexa.com]
+  },
+
+  # Amazon
+  'crawler-54-166-7-90.amazonadbot.com' => {
+    a: %w[54.166.7.90]
+  },
+  '54.166.7.90' => {
+    ptr: %w[crawler-54-166-7-90.amazonadbot.com]
+  },
+
+  # Apple
+  '17-58-98-60.applebot.apple.com' => {
+    a: %w[17.58.98.60]
+  },
+  '17.58.98.60' => {
+    ptr: %w[17-58-98-60.applebot.apple.com]
+  },
+
+  # Google
+  'crawl-66-249-64-141.googlebot.com' => {
+    a: %w[66.249.64.141]
+  },
+  '66.249.64.141' => {
+    ptr: %w[crawl-66-249-64-141.googlebot.com]
+  },
+
+  # Petalbot
+  'petalbot-114-119-134-10.petalsearch.com' => {
+    a: %w[114.119.134.10]
+  },
+  '114.119.134.10' => {
+    ptr: %w[petalbot-114-119-134-10.petalsearch.com]
+  },
+
+  # Pinterest
+  'crawl-54-236-1-11.pinterest.com' => {
+    a: %w[54.236.1.11]
+  },
+  '54.236.1.11' => {
+    ptr: %w[crawl-54-236-1-11.pinterest.com]
+  }
+}.freeze
+
+class DnsServer
+  class << self
+    attr_accessor :mock
+  end
+
+  @mock = DnsMock.start_server
+end
+
+module DnsServerMock
+  def before_all
+    super
+    DnsServer.mock.assign_mocks TEST_DNS_RECORDS
+    Legitbot.resolver_config = {
+      nameserver: 'localhost',
+      nameserver_port: [['localhost', DnsServer.mock.port]]
+    }
+  end
+
+  def after_all
+    Legitbot.resolver_config = nil
+    DnsServer.mock.reset_mocks!
+    super
+  end
+end

--- a/test/petalbot_test.rb
+++ b/test/petalbot_test.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
 require 'minitest/autorun'
+require 'minitest/hooks/test'
+require 'lib/dns_server_mock'
 require 'legitbot'
 
 class PetalbotTest < Minitest::Test
+  include Minitest::Hooks
+  include DnsServerMock
+
   def test_malicious_ip
     ip = '149.210.164.47'
     match = Legitbot::Petalbot.new ip

--- a/test/pinterest_test.rb
+++ b/test/pinterest_test.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
 require 'minitest/autorun'
+require 'minitest/hooks/test'
+require 'lib/dns_server_mock'
 require 'legitbot'
 
 class PinterestTest < Minitest::Test
+  include Minitest::Hooks
+  include DnsServerMock
+
   def test_malicious_ip
     ip = '149.210.164.47'
     match = Legitbot::Pinterest.new ip


### PR DESCRIPTION
Relying on the environment in tests is not reliable, especially when some crawlers implement frequent changes to their DNS.