### PR TITLE
Custom Rubocop cop to update crawler IPs [issue #57]

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 require:
-- rubocop-minitest
+  - rubocop-minitest
+  - rubocop/cop/custom
 
 AllCops:
   CacheRootDirectory: 'vendor'
@@ -14,3 +15,6 @@ Naming/MemoizedInstanceVariableName:
 
 Style/MapToHash:
   Enabled: false
+
+Custom/IpRanges:
+  Enabled: true

--- a/legitbot.gemspec
+++ b/legitbot.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'dns_mock', '~> 1.5.0', '>= 1.5.0'
   spec.add_development_dependency 'minitest', '~> 5.1', '>= 5.1.0'
   spec.add_development_dependency 'minitest-hooks', '~> 1.5', '>= 1.5.0'
+  spec.add_development_dependency 'nokogiri', '~> 1.13.0', '>= 1.13.0'
   spec.add_development_dependency 'rake', '~> 13.0', '>= 13.0.0'
   spec.add_development_dependency 'rubocop', '~> 1.24.0', '>= 1.24.0'
   spec.add_development_dependency 'rubocop-minitest', '~> 0.17.0', '>= 0.17.0'

--- a/lib/legitbot/duckduckgo.rb
+++ b/lib/legitbot/duckduckgo.rb
@@ -3,6 +3,8 @@
 module Legitbot # :nodoc:
   # https://duckduckgo.com/duckduckbot
   class DuckDuckGo < BotMatch
+    # @fetch:url https://help.duckduckgo.com/duckduckgo-help-pages/results/duckduckbot/
+    # @fetch:selector section.main article.content ul > li
     ip_ranges %w[
       20.191.45.212
       40.88.21.235

--- a/lib/rubocop/cop/custom.rb
+++ b/lib/rubocop/cop/custom.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative 'custom/ip_ranges'

--- a/lib/rubocop/cop/custom/ip_ranges.rb
+++ b/lib/rubocop/cop/custom/ip_ranges.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'ipaddr'
+require 'net/http'
+require 'nokogiri'
+require 'rubocop'
+require 'uri'
+
+module RuboCop
+  module Cop
+    module Custom
+      class IpRanges < Base # :nodoc:
+        extend AutoCorrector
+
+        MSG = 'Outdated list of IP ranges compared to %<url>s'
+        REGEXP = /^\s*#\s*@fetch:(?<param>[a-z0-9_]+)\s+(?<arg>.*)?/
+
+        def_node_matcher :on_ip_ranges, <<~PATTERN
+          (send nil? :ip_ranges $(array str+))
+        PATTERN
+
+        def on_send(node)
+          on_ip_ranges(node) do |value|
+            params = fetch_params(node)
+            return unless mandatory_params?(params)
+
+            existing_ips = read_node_ips value
+            new_ips = fetch_ips(**params)
+            return if existing_ips == new_ips
+
+            register_offense(value, new_ips, **params)
+          end
+        end
+
+        # def autocorrect(node)
+        #   -> (corrector) do
+        #     corrector.replace node, "new_ips"
+        #   end
+        # end
+
+        private
+
+        def fetch_ips(url:, selector:)
+          response = Net::HTTP.get_response URI(url)
+          response.value
+
+          document = Nokogiri::HTML response.body
+          document.css(selector).map(&:content).sort_by(&IPAddr.method(:new))
+        end
+
+        def read_node_ips(value)
+          value.child_nodes.map(&:value).sort_by(&IPAddr.method(:new))
+        end
+
+        def register_offense(node, new_ips, **params)
+          message = format(MSG, params)
+          add_offense node, message: message do |corrector|
+            corrector.replace node, node_replacement(new_ips)
+          end
+        end
+
+        def mandatory_params?(params)
+          params.include?(:url) && params.include?(:selector)
+        end
+
+        def fetch_params(node)
+          comments = processed_source.ast_with_comments[node]
+          comments.map do |comment|
+            match = comment.text.match(REGEXP)
+            next unless match
+
+            [match[:param].to_sym, match[:arg]]
+          end.compact.to_h
+        end
+
+        def node_replacement(new_ips)
+          contents = new_ips.join("\n")
+          "%w[\n#{contents}\n]"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
`ip_ranges` may define URL and a CSS selector of the page with up-to-date list of IP ranges, e.g.

```ruby
    # @fetch:url https://help.duckduckgo.com/duckduckgo-help-pages/results/duckduckbot/
    # @fetch:selector section.main article.content ul > li
    ip_ranges %w[
      <list of IPs>
    ]
```
