### PR TITLE
Keep filters in simplecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -13,7 +13,3 @@ coverage:
 
 comment:
   require_changes: true
-
-ignore:
-  - lib/rubocop
-  - test/

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 require 'simplecov'
-SimpleCov.start
-
 require 'simplecov-cobertura'
-SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
+SimpleCov.start do
+  formatter SimpleCov::Formatter::CoberturaFormatter
+  add_filter %r{^/lib/rubocop/}
+  add_filter %r{^/test/}
+end
 
 require 'legitbot'
 


### PR DESCRIPTION
I might want to replace `codecov` with another SaaS, while `simplecov` is an open source library and is here hopefully for longer.