### PR TITLE
Add Google inspection tool to the google bot list

### DIFF
--- a/lib/legitbot/google.rb
+++ b/lib/legitbot/google.rb
@@ -20,5 +20,6 @@ module Legitbot # :nodoc:
     googleweblight
     Storebot-Google
     Google-Site-Verification
+    Google-InspectionTool
   ]
 end


### PR DESCRIPTION
This user agent is used by Google when using the URL inspection tool from the Google search console.

https://developers.google.com/search/docs/crawling-indexing/overview-google-crawlers#google-inspectiontool