### PR TITLE
nil user_agent values should not raise exceptions

### DIFF
--- a/lib/legitbot/legitbot.rb
+++ b/lib/legitbot/legitbot.rb
@@ -21,7 +21,7 @@ module Legitbot
   # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def self.bot(user_agent, ip)
     bots = @rules
-           .select { |rule| rule[:fragments].any? { |f| user_agent.index f } }
+           .select { |rule| rule[:fragments].any? { |f| user_agent&.index f } }
            .map { |rule| rule[:class].new(ip) }
 
     selected = bots.select(&:valid?).first if bots.size > 1

--- a/test/legitbot_test.rb
+++ b/test/legitbot_test.rb
@@ -11,4 +11,8 @@ class LegitbotTest < Minitest::Test
       flunk 'No bot Firefox is possible'
     end
   end
+
+  def test_nil_ua
+    assert_nil Legitbot.bot(nil, '127.0.0.1')
+  end
 end


### PR DESCRIPTION
This is necessary to avoid LegitBot throwing pointless exceptions in testing contexts where there is no real browser providing a user agent value. Better to just return nil.